### PR TITLE
feat(DataArray): add getTransferableState() to avoid OOM on large arrays

### DIFF
--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -279,6 +279,13 @@ export interface vtkDataArray extends vtkObject {
   getState(): object;
 
   /**
+   * Like getState(), but preserves TypedArray values without
+   * converting and copying to a plain Array.
+   * @returns {object}
+   */
+  getTransferableState(): object;
+
+  /**
    * Deep copy of another vtkDataArray into this one.
    * @param {vtkDataArray} other
    */

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -483,6 +483,40 @@ function vtkDataArray(publicAPI, model) {
     return sortedObj;
   };
 
+  // Like getState(), but preserves TypedArray values without
+  // converting and copying to a plain Array.
+  publicAPI.getTransferableState = () => {
+    if (model.deleted) {
+      return null;
+    }
+    const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
+
+    // values stays as TypedArray — no Array.from conversion
+    delete jsonArchive.buffer;
+
+    // Clean any empty data
+    Object.keys(jsonArchive).forEach((keyName) => {
+      if (!jsonArchive[keyName]) {
+        delete jsonArchive[keyName];
+      }
+    });
+
+    // Sort resulting object by key name
+    const sortedObj = {};
+    Object.keys(jsonArchive)
+      .sort()
+      .forEach((name) => {
+        sortedObj[name] = jsonArchive[name];
+      });
+
+    // Remove mtime
+    if (sortedObj.mtime) {
+      delete sortedObj.mtime;
+    }
+
+    return sortedObj;
+  };
+
   /**
    * @param {import("./index").vtkDataArray} other
    */

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+import vtk from 'vtk.js/Sources/vtk';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
@@ -505,6 +506,55 @@ test('Test vtkDataArray resize function', (t) => {
 
   t.ok(da.getNumberOfTuples() === 4, '2 more tuples');
   t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on shrink');
+
+  t.end();
+});
+
+test('Test vtkDataArray getTransferableState preserves TypedArray values', (t) => {
+  const values = new Uint8Array([1, 2, 3, 4, 5]);
+  const da = vtkDataArray.newInstance({ values });
+
+  const state = da.getTransferableState();
+
+  t.ok(ArrayBuffer.isView(state.values), 'values is a TypedArray');
+  t.notOk(Array.isArray(state.values), 'values is not a plain Array');
+  t.ok(state.values instanceof Uint8Array, 'TypedArray type is preserved');
+
+  // Round-trip via vtk() reconstruction should work with TypedArray values
+  const da2 = vtk(state);
+  t.ok(da2, 'Can reconstruct from state with TypedArray values');
+  t.deepEqual(
+    Array.from(da2.getData()),
+    Array.from(values),
+    'Values are preserved after round-trip'
+  );
+  t.equal(
+    da2.getDataType(),
+    'Uint8Array',
+    'Data type preserved after round-trip'
+  );
+
+  t.end();
+});
+
+test('Test vtkDataArray getTransferableState does not OOM on large arrays', (t) => {
+  // Array.from() on a large TypedArray creates a plain JS Array with boxed
+  // Numbers, easily exceeding browser memory limits (RangeError).
+  // Real-world case: 1024x1024x256 labelmap = 268M Uint8 elements (~1.6GB
+  // as boxed Numbers). We use 10M here to keep tests fast while still
+  // being large enough that Array.from() would waste ~80MB of heap.
+  const size = 10_000_000;
+  const values = new Uint8Array(size);
+  values[0] = 42;
+  values[size - 1] = 99;
+
+  const da = vtkDataArray.newInstance({ values });
+
+  const state = da.getTransferableState();
+  t.ok(ArrayBuffer.isView(state.values), 'Large TypedArray preserved in state');
+  t.equal(state.values.length, size, 'Correct length preserved');
+  t.equal(state.values[0], 42, 'First value preserved');
+  t.equal(state.values[size - 1], 99, 'Last value preserved');
 
   t.end();
 });

--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.js
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.js
@@ -11,6 +11,7 @@ const { vtkErrorMacro, vtkWarningMacro } = macro;
 function vtkFieldData(publicAPI, model) {
   model.classHierarchy.push('vtkFieldData');
   const superGetState = publicAPI.getState;
+  const superGetTransferableState = publicAPI.getTransferableState;
 
   // Decode serialized data if any
   if (model.arrays) {
@@ -257,6 +258,16 @@ function vtkFieldData(publicAPI, model) {
     if (result) {
       result.arrays = model.arrays.map((item) => ({
         data: item.data.getState(),
+      }));
+    }
+    return result;
+  };
+
+  publicAPI.getTransferableState = () => {
+    const result = superGetTransferableState();
+    if (result) {
+      result.arrays = model.arrays.map((item) => ({
+        data: item.data.getTransferableState(),
       }));
     }
     return result;

--- a/Sources/interfaces.d.ts
+++ b/Sources/interfaces.d.ts
@@ -263,6 +263,21 @@ export interface vtkObject {
   toJSON(): object;
 
   /**
+   * Like getState(), but preserves TypedArrays without converting
+   * and copying to plain Arrays.
+   *
+   * The returned state is compatible with vtk() for reconstruction
+   * and with structured clone / postMessage.
+   *
+   * ```
+   * const state = dataset.getTransferableState();
+   * worker.postMessage(state);
+   * // in worker: const dataset = vtk(state);
+   * ```
+   */
+  getTransferableState(): object;
+
+  /**
    * Try to copy the state of the other to ourselves by just using references.
    *
    * @param {vtkObject} other instance to copy the reference from

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -219,6 +219,13 @@ function getStateArrayMapFunc(item) {
   return item;
 }
 
+function getTransferableStateArrayMapFunc(item) {
+  if (item && item.isA) {
+    return item.getTransferableState();
+  }
+  return item;
+}
+
 // ----------------------------------------------------------------------------
 // setImmediate
 // ----------------------------------------------------------------------------
@@ -441,6 +448,45 @@ export function obj(publicAPI = {}, model = {}) {
   // JSON.stringify will only stringify the return value of this function
   publicAPI.toJSON = function vtkObjToJSON() {
     return publicAPI.getState();
+  };
+
+  // Like getState(), but preserves TypedArrays for efficient structured
+  // clone / postMessage transfer instead of converting them to plain Arrays.
+  publicAPI.getTransferableState = () => {
+    if (model.deleted) {
+      return null;
+    }
+    const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
+
+    Object.keys(jsonArchive).forEach((keyName) => {
+      if (
+        jsonArchive[keyName] === null ||
+        jsonArchive[keyName] === undefined ||
+        keyName[0] === '_'
+      ) {
+        delete jsonArchive[keyName];
+      } else if (jsonArchive[keyName].isA) {
+        jsonArchive[keyName] = jsonArchive[keyName].getTransferableState();
+      } else if (Array.isArray(jsonArchive[keyName])) {
+        jsonArchive[keyName] = jsonArchive[keyName].map(
+          getTransferableStateArrayMapFunc
+        );
+      }
+      // TypedArrays are preserved (no Array.from conversion)
+    });
+
+    const sortedObj = {};
+    Object.keys(jsonArchive)
+      .sort()
+      .forEach((name) => {
+        sortedObj[name] = jsonArchive[name];
+      });
+
+    if (sortedObj.mtime) {
+      delete sortedObj.mtime;
+    }
+
+    return sortedObj;
   };
 
   // Allow usage as decorator


### PR DESCRIPTION
### Context

`vtkDataArray.getState()` calls `Array.from()` on typed array values, which creates a plain JS Array with boxed Numbers. For large arrays this causes an out-of-memory crash (RangeError: Invalid array length).

Real-world case: [Kitware/VolView#852](https://github.com/Kitware/VolView/issues/852) — saving a session with a 1024×1024×256 labelmap (268M Uint8 elements) crashes because `Array.from()` tries to allocate ~1.6GB of heap for the boxed Number array.

The `Array.from()` conversion in the base `getState()` was added in [#2927](https://github.com/Kitware/vtk-js/pull/2927) to fix JSON serialization of `Float64Array` properties like `direction` ([Kitware/glance#480](https://github.com/Kitware/glance/issues/480)). That fix is correct for small typed arrays, but causes OOM for large DataArray values.

Kitware maintainers have previously recommended sending TypedArrays separately from JSON state for large data — see [this Discourse thread on web workers](https://discourse.vtk.org/t/vtk-and-web-workers/5536) and [this thread on REST API serialization](https://discourse.vtk.org/t/vtk-js-how-to-serialize-and-deserialize-vtkdataset-for-rest-apis/6634). `getTransferableState()` formalizes that pattern in the API.

### Results

**Before:** No built in way to serialize DataArrays without copys of TypedArrays.
**After:** `getTransferableState()` preserves TypedArray values without converting and copying to plain Arrays. `getState()` behavior is unchanged.

### Changes

- **`macros.js`**: Added `getTransferableState()` to the base `vtkObject`. Same as `getState()` but preserves TypedArrays and calls `getTransferableState()` on nested objects.
- **`DataArray/index.js`**: Added `getTransferableState()` override that skips the `Array.from()` conversion on values.
- **`FieldData.js`**: Added `getTransferableState()` override that calls `getTransferableState()` on nested DataArrays.
- **`interfaces.d.ts`**, **`DataArray/index.d.ts`**: Added TypeScript definitions for `getTransferableState()`.
- **`testDataArray.js`**: Added tests for TypedArray preservation and large array handling via `getTransferableState()`.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master (f60fdaa508c)
  - **OS**: Linux (WSL2 Ubuntu 22.04)
  - **Browser**: Chrome Headless 138.0.0.0