### PR TITLE
feat(DataArray): add preserveTypedArrays option to getState()

### DIFF
--- a/Sources/Common/Core/DataArray/index.d.ts
+++ b/Sources/Common/Core/DataArray/index.d.ts
@@ -1,4 +1,4 @@
-import { vtkObject, vtkRange } from '../../../interfaces';
+import { vtkObject, vtkRange, GetStateOptions } from '../../../interfaces';
 import { float, int, Nullable, Range, TypedArray } from '../../../types';
 
 /**
@@ -274,9 +274,12 @@ export interface vtkDataArray extends vtkObject {
 
   /**
    * Get the state of this array.
+   *
+   * Pass `{ preserveTypedArrays: true }` to keep TypedArray values
+   * without converting and copying to a plain Array.
    * @returns {object}
    */
-  getState(): object;
+  getState(options?: GetStateOptions): object;
 
   /**
    * Deep copy of another vtkDataArray into this one.

--- a/Sources/Common/Core/DataArray/index.js
+++ b/Sources/Common/Core/DataArray/index.js
@@ -450,14 +450,15 @@ function vtkDataArray(publicAPI, model) {
   };
 
   // Override serialization support
-  publicAPI.getState = () => {
+  publicAPI.getState = ({ preserveTypedArrays = false } = {}) => {
     if (model.deleted) {
       return null;
     }
     const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
 
-    // Convert typed array to regular array
-    jsonArchive.values = Array.from(jsonArchive.values);
+    if (!preserveTypedArrays) {
+      jsonArchive.values = Array.from(jsonArchive.values);
+    }
     delete jsonArchive.buffer;
 
     // Clean any empty data

--- a/Sources/Common/Core/DataArray/test/testDataArray.js
+++ b/Sources/Common/Core/DataArray/test/testDataArray.js
@@ -1,4 +1,5 @@
 import test from 'tape';
+import vtk from 'vtk.js/Sources/vtk';
 import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
 import { VtkDataTypes } from 'vtk.js/Sources/Common/Core/DataArray/Constants';
 import * as vtkMath from 'vtk.js/Sources/Common/Core/Math';
@@ -505,6 +506,34 @@ test('Test vtkDataArray resize function', (t) => {
 
   t.ok(da.getNumberOfTuples() === 4, '2 more tuples');
   t.equal(da.getData().buffer, oldData.buffer, 'no array allocation on shrink');
+
+  t.end();
+});
+
+test('Test vtkDataArray getState preserveTypedArrays option', (t) => {
+  const values = new Uint8Array([1, 2, 3, 4, 5]);
+  const da = vtkDataArray.newInstance({ values });
+
+  // Default: values converted to plain Array
+  const state = da.getState();
+  t.ok(Array.isArray(state.values), 'default getState returns plain Array');
+
+  // With option: values preserved as TypedArray
+  const transferable = da.getState({ preserveTypedArrays: true });
+  t.ok(
+    transferable.values instanceof Uint8Array,
+    'TypedArray type is preserved'
+  );
+
+  // Round-trip via vtk() works with TypedArray values
+  const da2 = vtk(transferable);
+  t.ok(da2, 'Can reconstruct from state with TypedArray values');
+  t.deepEqual(
+    Array.from(da2.getData()),
+    Array.from(values),
+    'Values preserved after round-trip'
+  );
+  t.equal(da2.getDataType(), 'Uint8Array', 'Data type preserved');
 
   t.end();
 });

--- a/Sources/Common/DataModel/DataSetAttributes/FieldData.js
+++ b/Sources/Common/DataModel/DataSetAttributes/FieldData.js
@@ -252,11 +252,11 @@ function vtkFieldData(publicAPI, model) {
   publicAPI.getNumberOfTuples = () =>
     model.arrays.length > 0 ? model.arrays[0].getNumberOfTuples() : 0;
 
-  publicAPI.getState = () => {
-    const result = superGetState();
+  publicAPI.getState = (options) => {
+    const result = superGetState(options);
     if (result) {
       result.arrays = model.arrays.map((item) => ({
-        data: item.data.getState(),
+        data: item.data.getState(options),
       }));
     }
     return result;

--- a/Sources/interfaces.d.ts
+++ b/Sources/interfaces.d.ts
@@ -2,6 +2,18 @@ import vtkDataArray from './Common/Core/DataArray';
 import { vtkPipelineConnection } from './types';
 import { EVENT_ABORT, VOID } from './macros';
 
+export interface GetStateOptions {
+  /**
+   * When true, TypedArrays are preserved without converting and
+   * copying to plain Arrays. Use for structured clone / postMessage.
+   *
+   * Note: the resulting state is not JSON-safe. TypedArrays serialize
+   * as `{"0":v,"1":v,...}` via `JSON.stringify`, not as arrays.
+   * @default false
+   */
+  preserveTypedArrays?: boolean;
+}
+
 /**
  * Object returned on any subscription call
  */
@@ -241,15 +253,20 @@ export interface vtkObject {
    * Such state can then be reused to clone or rebuild a full
    * vtkObject tree using the root vtk() function.
    *
-   * The following example will grab mapper and dataset that are
-   * beneath the vtkActor instance as well.
-   *
    * ```
    * const actorStr = JSON.stringify(actor.getState());
    * const newActor = vtk(JSON.parse(actorStr));
    * ```
+   *
+   * Pass `{ preserveTypedArrays: true }` to keep TypedArrays
+   * without converting and copying to plain Arrays. Useful for
+   * structured clone / postMessage transfers.
+   *
+   * ```
+   * worker.postMessage(dataset.getState({ preserveTypedArrays: true }));
+   * ```
    */
-  getState(): object;
+  getState(options?: GetStateOptions): object;
 
   /**
    * Used internally by JSON.stringify to get the content to serialize.

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -368,10 +368,11 @@ export function obj(publicAPI = {}, model = {}) {
   };
 
   // Add serialization support
-  publicAPI.getState = () => {
+  publicAPI.getState = ({ preserveTypedArrays = false } = {}) => {
     if (model.deleted) {
       return null;
     }
+    const options = { preserveTypedArrays };
     const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
 
     // Convert every vtkObject to its serializable form
@@ -383,10 +384,12 @@ export function obj(publicAPI = {}, model = {}) {
       ) {
         delete jsonArchive[keyName];
       } else if (jsonArchive[keyName].isA) {
-        jsonArchive[keyName] = jsonArchive[keyName].getState();
+        jsonArchive[keyName] = jsonArchive[keyName].getState(options);
       } else if (Array.isArray(jsonArchive[keyName])) {
-        jsonArchive[keyName] = jsonArchive[keyName].map(getStateArrayMapFunc);
-      } else if (isTypedArray(jsonArchive[keyName])) {
+        jsonArchive[keyName] = jsonArchive[keyName].map((item) =>
+          item && item.isA ? item.getState(options) : item
+        );
+      } else if (!preserveTypedArrays && isTypedArray(jsonArchive[keyName])) {
         jsonArchive[keyName] = Array.from(jsonArchive[keyName]);
       }
     });


### PR DESCRIPTION
### Context

`vtkDataArray.getState()` calls `Array.from()` on typed array values, which creates a plain JS Array with Numbers. For large arrays this causes an out-of-memory crash (RangeError: Invalid array length).

Real-world case: [Kitware/VolView#852](https://github.com/Kitware/VolView/issues/852) — saving a session with a 1024×1024×256 labelmap (268M Uint8 elements) crashes because `Array.from()` tries to allocate ~1.6GB of heap for the boxed Number array.

The `Array.from()` conversion in the base `getState()` was added in [#2927](https://github.com/Kitware/vtk-js/pull/2927) to fix JSON serialization of `Float64Array` properties like `direction` ([Kitware/glance#480](https://github.com/Kitware/glance/issues/480)).

Related: see [this Discourse thread on web workers](https://discourse.vtk.org/t/vtk-and-web-workers/5536) and [this thread on REST API serialization](https://discourse.vtk.org/t/vtk-js-how-to-serialize-and-deserialize-vtkdataset-for-rest-apis/6634). The `preserveTypedArrays` option formalizes that pattern in the existing API.

If this gets merged, should open another breaking change PR to remove `getStateArrayMapFunc` from `macros.js`.

### Results

**Before:** No built-in way to serialize DataArrays without copying TypedArrays to plain Arrays.
**After:** `getState({ preserveTypedArrays: true })` preserves TypedArray values without converting and copying. Default `getState()` behavior is unchanged.

```js
// Default — JSON-safe, same as before
const jsonState = dataset.getState();
JSON.stringify(jsonState); // works

// New option — efficient for structured clone / postMessage
const state = dataset.getState({ preserveTypedArrays: true });
worker.postMessage(state);
```

### Changes

- **`macros.js`**: Added `preserveTypedArrays` option to the base `getState()`. When true, skips `Array.from()` on TypedArrays and propagates the option to nested objects.
- **`DataArray/index.js`**: Updated `getState()` to conditionally skip `Array.from()` on values when `preserveTypedArrays` is true.
- **`FieldData.js`**: Updated `getState()` to forward options to nested DataArrays.
- **`interfaces.d.ts`**: Added `GetStateOptions` type and updated `getState()` signature.
- **`DataArray/index.d.ts`**: Updated `getState()` signature.
- **`testDataArray.js`**: Added tests for `preserveTypedArrays` option.

- [x] Documentation and TypeScript definitions were updated to match those changes

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **OS**: Linux
  - **Browser**: Chrome Headless 138.0.0.0
