### PR TITLE
fix(ci): launch Firefox headed via Vitest browser option

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,10 +7,12 @@ jobs:
   build-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-24.04]
         node: [22]
-    name: ${{ matrix.os }} and node ${{ matrix.node }}
+        browser: [chromium, firefox]
+    name: ${{ matrix.os }} / node ${{ matrix.node }} / ${{ matrix.browser }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup project
@@ -25,16 +27,16 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ matrix.os }}-${{ steps.playwright.outputs.version }}
-      - name: Install Playwright browsers
+          key: playwright-${{ matrix.os }}-${{ matrix.browser }}-${{ steps.playwright.outputs.version }}
+      - name: Install Playwright browser
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium firefox
+        run: npx playwright install ${{ matrix.browser }}
       - name: Install Playwright system deps
-        run: sudo npx playwright install-deps chromium firefox
+        run: sudo npx playwright install-deps ${{ matrix.browser }}
       - name: Build
         run: npm run build:release
       - name: Archive build output
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'merge_group' && matrix.browser == 'chromium'
         uses: actions/upload-artifact@v7
         with:
           name: build-results-${{ matrix.os }}-node_${{ matrix.node }}
@@ -44,13 +46,15 @@ jobs:
         run: |
           npx tsc -p tsconfig.esm-check.json
           npx tsc -p tsconfig.umd-check.json
-      - name: Chrome and Firefox tests
+      - name: Tests
+        env:
+          TEST_BROWSER: ${{ matrix.browser }}
         run: xvfb-run --auto-servernum npm test
       - name: Archive test results
         if: github.event_name != 'merge_group' && (success() || failure())
         uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
-          name: test-results-${{ matrix.os }}-node_${{ matrix.node }}
+          name: test-results-${{ matrix.os }}-node_${{ matrix.node }}-${{ matrix.browser }}
           path: Utilities/TestResults/
           retention-days: 15

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -46,6 +46,17 @@ jobs:
         run: |
           npx tsc -p tsconfig.esm-check.json
           npx tsc -p tsconfig.umd-check.json
+      - name: Smoke-test packed ESM tarball
+        if: matrix.browser == 'chromium'
+        run: |
+          tarball=$(npm pack ./dist/esm --silent)
+          mkdir -p /tmp/vtk-smoke
+          cd /tmp/vtk-smoke
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund "$GITHUB_WORKSPACE/$tarball"
+          node -e "require('@kitware/vtk.js/Utilities/config/rules-vtk')"
+          node -e "require('@kitware/vtk.js/Utilities/config/chainWebpack')"
+          npx --no-install vtkDataConverter --help
       - name: Tests
         env:
           TEST_BROWSER: ${{ matrix.browser }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 coverage/
 .env
 Utilities/TestResults
+.vitest-attachments/
 .idea
 Documentation/.vitepress/cache/
 Documentation/.vitepress/dist/

--- a/Utilities/build/vtk-plugins.mjs
+++ b/Utilities/build/vtk-plugins.mjs
@@ -123,11 +123,24 @@ export function copyEsmAssetsPlugin({ esmOutputDir }) {
         'Utilities/DataGenerator',
         `${esmOutputDir}/Utilities/DataGenerator`
       );
+      copyDir('Utilities/config', `${esmOutputDir}/Utilities/config`);
       fs.mkdirSync(`${esmOutputDir}/Utilities`, { recursive: true });
       fs.copyFileSync(
         'Utilities/prepare.js',
         `${esmOutputDir}/Utilities/prepare.js`
       );
+
+      // Flip these CJS subdirs back to CommonJS scope (root is type: module).
+      for (const dir of [
+        'Utilities/config',
+        'Utilities/XMLConverter',
+        'Utilities/DataGenerator',
+      ]) {
+        fs.writeFileSync(
+          `${esmOutputDir}/${dir}/package.json`,
+          `${JSON.stringify({ type: 'commonjs' }, null, 2)}\n`
+        );
+      }
 
       fs.copyFileSync(
         'Utilities/build/macro-shim.d.ts',

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -8,34 +8,29 @@ const webGPU = !!process.env.WEBGPU;
 const testBrowser = process.env.TEST_BROWSER || 'chromium';
 const ci = !!process.env.CI;
 
-// Per-instance launch.headless is load-bearing for Firefox WebGL on Linux CI;
-// the top-level browser.headless takes a different launch path that drops WebGL.
+const firefoxUserPrefs = {
+  'dom.webgpu.enabled': true, // off by default on Linux Firefox
+  'webgl.force-enabled': true, // override GPU blocklist (no real GPU on CI)
+  'webgl.disable-fail-if-major-performance-caveat': true, // accept llvmpipe
+};
+
+const chromiumArgs = ci
+  ? ['--no-sandbox', '--enable-unsafe-swiftshader', '--use-angle=swiftshader']
+  : [];
+
 const firefox = {
   browser: 'firefox',
-  launch: {
-    headless: true,
-    firefoxUserPrefs: {
-      'dom.webgpu.enabled': true, // off by default on Linux Firefox
-      'webgl.force-enabled': true, // override GPU blocklist (no real GPU on CI)
-      'webgl.disable-fail-if-major-performance-caveat': true, // accept llvmpipe
-    },
-  },
+  headless: false, // supported Vitest Browser option; xvfb-run supplies the display on CI
 };
 
 function buildBrowserInstances() {
-  if (ci) {
-    return [
-      {
-        browser: 'chromium',
-        launch: {
-          headless: true,
-          args: ['--no-sandbox', '--enable-unsafe-swiftshader', '--use-angle=swiftshader'],
-        },
-      },
-      firefox,
-    ];
-  }
-  return [testBrowser === 'firefox' ? firefox : { browser: 'chromium', launch: { headless: true } }];
+  if (testBrowser === 'firefox') return [firefox];
+  return [{ browser: 'chromium' }];
+}
+
+function buildPlaywrightLaunchOptions() {
+  if (testBrowser === 'firefox') return { firefoxUserPrefs };
+  return chromiumArgs.length ? { args: chromiumArgs } : {};
 }
 
 export default defineConfig({
@@ -82,7 +77,9 @@ export default defineConfig({
     browser: {
       enabled: true,
       headless: true,
-      provider: playwright(),
+      provider: playwright({
+        launchOptions: buildPlaywrightLaunchOptions(),
+      }),
       instances: buildBrowserInstances(),
     },
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -77,6 +77,7 @@ export default defineConfig({
     browser: {
       enabled: true,
       headless: true,
+      screenshotDirectory: 'Utilities/TestResults/screenshots',
       provider: playwright({
         launchOptions: buildPlaywrightLaunchOptions(),
       }),


### PR DESCRIPTION
This PR targets the PaulHax mirror of Kitware/vtk-js#3435 (`pr-3435`) and contains only the CI Firefox WebGL fix.

What changed:

- Split Build and Test into a browser matrix so Chromium and Firefox run in separate jobs.
- Install/cache only the Playwright browser needed by each matrix lane.
- Set `TEST_BROWSER` from the matrix so Vitest runs one browser per job.
- Launch Firefox using the supported Vitest Browser instance `headless: false` option under `xvfb-run`.
- Pass Firefox WebGL prefs and Chromium SwiftShader args through `@vitest/browser-playwright` provider `launchOptions`, since `instances[].launch` is not consumed by Vitest 4.1.6.

Why:

The previous Firefox config used `browser.instances[].launch.headless`, but Vitest 4.1.6 does not feed that field into Playwright. It effectively launched Firefox as `firefox.launch({ headless: true })`, which produced the CI `no webgl context` failures. This branch feeds Firefox as `firefox.launch({ firefoxUserPrefs, headless: false })`.

Validation on PaulHax/vtk-js#25:

- 5 total Build and Test attempts passed on the same SHA.
- Firefox passed all 5 attempts with `376 passed`, `7 skipped`, `0` `no webgl context`, and `0` `target Proxy null`.
- Local config import checks confirmed the Firefox and Chromium launch options resolve as intended.
