### PR TITLE
fix(PolyDataMapper2D): restore cull face state

### DIFF
--- a/Sources/Rendering/OpenGL/Actor/index.js
+++ b/Sources/Rendering/OpenGL/Actor/index.js
@@ -142,10 +142,16 @@ function vtkOpenGLActor(publicAPI, model) {
     if (prepass) {
       model.context.depthMask(true);
       publicAPI.activateTextures();
-    } else if (model.activeTextures) {
-      for (let index = 0; index < model.activeTextures.length; index++) {
-        model.activeTextures[index].deactivate();
+    } else {
+      if (model.activeTextures) {
+        for (let index = 0; index < model.activeTextures.length; index++) {
+          model.activeTextures[index].deactivate();
+        }
       }
+      // Restore baseline cull state so a mapper that enabled culling
+      // cannot leak into later actors or the next renderer's clear().
+      // Mirrors C++ vtkOpenGLProperty::PostRender.
+      model._openGLRenderWindow.disableCullFace();
     }
   };
 
@@ -157,10 +163,13 @@ function vtkOpenGLActor(publicAPI, model) {
           model.renderable.getNestedPickable()
       );
       publicAPI.activateTextures();
-    } else if (model.activeTextures) {
-      for (let index = 0; index < model.activeTextures.length; index++) {
-        model.activeTextures[index].deactivate();
+    } else {
+      if (model.activeTextures) {
+        for (let index = 0; index < model.activeTextures.length; index++) {
+          model.activeTextures[index].deactivate();
+        }
       }
+      model._openGLRenderWindow.disableCullFace();
     }
   };
 

--- a/Sources/Rendering/OpenGL/Actor2D/index.js
+++ b/Sources/Rendering/OpenGL/Actor2D/index.js
@@ -129,11 +129,16 @@ function vtkOpenGLActor2D(publicAPI, model) {
     if (prepass) {
       model.context.depthMask(true);
       publicAPI.activateTextures();
-    } else if (model.activeTextures) {
-      // deactivate textures
-      for (let index = 0; index < model.activeTextures.length; index++) {
-        model.activeTextures[index].deactivate();
+    } else {
+      if (model.activeTextures) {
+        for (let index = 0; index < model.activeTextures.length; index++) {
+          model.activeTextures[index].deactivate();
+        }
       }
+      // Restore baseline cull state so a mapper that enabled culling
+      // cannot leak into later actors or the next renderer's clear().
+      // Mirrors C++ vtkOpenGLProperty::PostRender.
+      model._openGLRenderWindow.disableCullFace();
     }
   };
 
@@ -142,10 +147,13 @@ function vtkOpenGLActor2D(publicAPI, model) {
     if (prepass) {
       model.context.depthMask(false);
       publicAPI.activateTextures();
-    } else if (model.activeTextures) {
-      for (let index = 0; index < model.activeTextures.length; index++) {
-        model.activeTextures[index].deactivate();
+    } else {
+      if (model.activeTextures) {
+        for (let index = 0; index < model.activeTextures.length; index++) {
+          model.activeTextures[index].deactivate();
+        }
       }
+      model._openGLRenderWindow.disableCullFace();
     }
   };
 
@@ -154,11 +162,13 @@ function vtkOpenGLActor2D(publicAPI, model) {
     if (prepass) {
       model.context.depthMask(true);
       publicAPI.activateTextures();
-    } else if (model.activeTextures) {
-      // deactivate textures
-      for (let index = 0; index < model.activeTextures.length; index++) {
-        model.activeTextures[index].deactivate();
+    } else {
+      if (model.activeTextures) {
+        for (let index = 0; index < model.activeTextures.length; index++) {
+          model.activeTextures[index].deactivate();
+        }
       }
+      model._openGLRenderWindow.disableCullFace();
     }
   };
 }

--- a/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
+++ b/Sources/Rendering/OpenGL/Glyph3DMapper/index.js
@@ -77,10 +77,10 @@ function vtkOpenGLGlyph3DMapper(publicAPI, model) {
       model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.FRONT);
+      model._openGLRenderWindow.setCullFaceMode(gl.FRONT);
     } else {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.BACK);
+      model._openGLRenderWindow.setCullFaceMode(gl.BACK);
     }
 
     publicAPI.renderPieceStart(ren, actor);

--- a/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
+++ b/Sources/Rendering/OpenGL/OrderIndependentTranslucentPass/index.js
@@ -333,7 +333,7 @@ function vtkOpenGLOrderIndependentTranslucentPass(publicAPI, model) {
     gl.depthFunc(gl.LEQUAL);
     if (cullFaceEnabled) {
       viewNode.enableCullFace();
-      gl.cullFace(cullFaceMode);
+      viewNode.setCullFaceMode(cullFaceMode);
     }
     model.translucentRGBATexture.deactivate();
     model.translucentRTexture.deactivate();

--- a/Sources/Rendering/OpenGL/PolyDataMapper/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper/index.js
@@ -1743,10 +1743,10 @@ function vtkOpenGLPolyDataMapper(publicAPI, model) {
       model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.FRONT);
+      model._openGLRenderWindow.setCullFaceMode(gl.FRONT);
     } else {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.BACK);
+      model._openGLRenderWindow.setCullFaceMode(gl.BACK);
     }
 
     publicAPI.renderPieceStart(ren, actor);

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/index.js
@@ -96,7 +96,7 @@ function vtkOpenGLPolyDataMapper2D(publicAPI, model) {
     // cull back face to avoid double drawing
     const gl = model.context;
     model._openGLRenderWindow.enableCullFace();
-    gl.cullFace(gl.BACK);
+    model._openGLRenderWindow.setCullFaceMode(gl.BACK);
 
     publicAPI.renderPieceStart(ren, actor);
     publicAPI.renderPieceDraw(ren, actor);

--- a/Sources/Rendering/OpenGL/PolyDataMapper2D/test/testCullFaceLeak.js
+++ b/Sources/Rendering/OpenGL/PolyDataMapper2D/test/testCullFaceLeak.js
@@ -1,0 +1,216 @@
+import test from 'tape';
+import testUtils from 'vtk.js/Sources/Testing/testUtils';
+
+import vtkDataArray from 'vtk.js/Sources/Common/Core/DataArray';
+import vtkImageData from 'vtk.js/Sources/Common/DataModel/ImageData';
+import vtkLineSource from 'vtk.js/Sources/Filters/Sources/LineSource';
+import vtkSphereSource from 'vtk.js/Sources/Filters/Sources/SphereSource';
+import vtkActor from 'vtk.js/Sources/Rendering/Core/Actor';
+import vtkActor2D from 'vtk.js/Sources/Rendering/Core/Actor2D';
+import vtkCoordinate from 'vtk.js/Sources/Rendering/Core/Coordinate';
+import vtkImageMapper from 'vtk.js/Sources/Rendering/Core/ImageMapper';
+import vtkImageSlice from 'vtk.js/Sources/Rendering/Core/ImageSlice';
+import vtkMapper from 'vtk.js/Sources/Rendering/Core/Mapper';
+import vtkMapper2D from 'vtk.js/Sources/Rendering/Core/Mapper2D';
+import vtkRenderer from 'vtk.js/Sources/Rendering/Core/Renderer';
+import vtkRenderWindow from 'vtk.js/Sources/Rendering/Core/RenderWindow';
+import 'vtk.js/Sources/Rendering/Misc/RenderingAPIs';
+
+import { SlicingMode } from 'vtk.js/Sources/Rendering/Core/ImageMapper/Constants';
+
+function createWhiteImage() {
+  const image = vtkImageData.newInstance();
+  image.setDimensions(16, 16, 1);
+  image.getPointData().setScalars(
+    vtkDataArray.newInstance({
+      numberOfComponents: 1,
+      values: new Uint8Array(16 * 16).fill(255),
+    })
+  );
+  return image;
+}
+
+function createImageSlice(image) {
+  const mapper = vtkImageMapper.newInstance();
+  mapper.setInputData(image);
+  mapper.setSlicingMode(SlicingMode.K);
+  mapper.setSlice(0);
+
+  const actor = vtkImageSlice.newInstance();
+  actor.setMapper(mapper);
+  actor.getProperty().setColorWindow(255);
+  actor.getProperty().setColorLevel(127);
+
+  return { actor, mapper };
+}
+
+// A leaking case enables CULL_FACE without restoring it. It returns the
+// resources to register for cleanup and a function to add it to a renderer.
+function makeLineActor2DCase() {
+  const line = vtkLineSource.newInstance({
+    point1: [2, 2, 0],
+    point2: [14, 14, 0],
+  });
+
+  const coordinate = vtkCoordinate.newInstance();
+  coordinate.setCoordinateSystemToWorld();
+
+  const mapper = vtkMapper2D.newInstance();
+  mapper.setInputConnection(line.getOutputPort());
+  mapper.setTransformCoordinate(coordinate);
+  mapper.setScalarVisibility(false);
+
+  const actor = vtkActor2D.newInstance();
+  actor.setMapper(mapper);
+
+  return {
+    resources: [actor, mapper, line, coordinate],
+    addToRenderer: (renderer) => renderer.addActor2D(actor),
+  };
+}
+
+function makeBackfaceCulledSphereCase() {
+  const source = vtkSphereSource.newInstance({
+    center: [7.5, 7.5, 0],
+    radius: 1,
+  });
+
+  const mapper = vtkMapper.newInstance();
+  mapper.setInputConnection(source.getOutputPort());
+
+  const actor = vtkActor.newInstance();
+  actor.setMapper(mapper);
+  actor.getProperty().setBackfaceCulling(true);
+
+  return {
+    resources: [actor, mapper, source],
+    addToRenderer: (renderer) => renderer.addActor(actor),
+  };
+}
+
+function setCameraToBackFace(renderer) {
+  const camera = renderer.getActiveCamera();
+  camera.setParallelProjection(true);
+  camera.setPosition(7.5, 7.5, -50);
+  camera.setFocalPoint(7.5, 7.5, 0);
+  camera.setViewUp(0, 1, 0);
+  camera.setParallelScale(9);
+  renderer.resetCameraClippingRange();
+}
+
+function addChildRenderWindow(
+  parentRenderWindow,
+  parentView,
+  container,
+  image
+) {
+  const renderWindow = vtkRenderWindow.newInstance();
+  parentRenderWindow.addRenderWindow(renderWindow);
+
+  const view = parentView.addMissingNode(renderWindow);
+  renderWindow.addView(view);
+  view.setContainer(container);
+  view.setSize(64, 64);
+  view.getCanvas().style.width = '64px';
+  view.getCanvas().style.height = '64px';
+
+  const renderer = vtkRenderer.newInstance();
+  renderer.setBackground(0, 0, 0);
+  renderWindow.addRenderer(renderer);
+
+  const imageSlice = createImageSlice(image);
+  renderer.addActor(imageSlice.actor);
+  setCameraToBackFace(renderer);
+
+  return { renderWindow, renderer, view, imageSlice };
+}
+
+function getCenterPixel(canvas) {
+  const context = canvas.getContext('2d');
+  const { data } = context.getImageData(
+    Math.floor(canvas.width / 2),
+    Math.floor(canvas.height / 2),
+    1,
+    1
+  );
+  return Array.from(data);
+}
+
+function isBright(pixel) {
+  return pixel[0] > 128 && pixel[1] > 128 && pixel[2] > 128 && pixel[3] > 0;
+}
+
+// child1 shows an image only. child2 shows an image plus a leaking actor.
+// Both children share one WebGL context. If the leaking actor's cull state
+// is not cleaned up, child1's back-facing image quad is culled on re-render.
+function runLeakTest(t, leakingCase) {
+  const gc = testUtils.createGarbageCollector(t);
+  const root = document.querySelector('body');
+  const childContainer1 = gc.registerDOMElement(document.createElement('div'));
+  const childContainer2 = gc.registerDOMElement(document.createElement('div'));
+  root.appendChild(childContainer1);
+  root.appendChild(childContainer2);
+
+  const parentRenderWindow = gc.registerResource(vtkRenderWindow.newInstance());
+  const parentView = gc.registerResource(
+    parentRenderWindow.newAPISpecificView('WebGL')
+  );
+  parentRenderWindow.addView(parentView);
+  parentView.initialize();
+
+  const image = gc.registerResource(createWhiteImage());
+  const child1 = addChildRenderWindow(
+    parentRenderWindow,
+    parentView,
+    childContainer1,
+    image
+  );
+  const child2 = addChildRenderWindow(
+    parentRenderWindow,
+    parentView,
+    childContainer2,
+    image
+  );
+
+  leakingCase.addToRenderer(child2.renderer);
+
+  [
+    child1.renderWindow,
+    child1.renderer,
+    child1.imageSlice.actor,
+    child1.imageSlice.mapper,
+    child2.renderWindow,
+    child2.renderer,
+    child2.imageSlice.actor,
+    child2.imageSlice.mapper,
+    ...leakingCase.resources,
+  ].forEach((resource) => gc.registerResource(resource));
+
+  parentView.resizeFromChildRenderWindows();
+
+  parentRenderWindow.render();
+  const firstRenderPixel = getCenterPixel(child1.view.getCanvas());
+  t.ok(
+    isBright(firstRenderPixel),
+    `first child slice is visible on initial render (${firstRenderPixel})`
+  );
+
+  parentRenderWindow.render();
+  const secondRenderPixel = getCenterPixel(child1.view.getCanvas());
+  t.ok(
+    isBright(secondRenderPixel),
+    `first child slice remains visible after leaking actor render (${secondRenderPixel})`
+  );
+
+  gc.releaseResources();
+}
+
+test.onlyIfWebGL(
+  'Test PolyDataMapper2D cull face does not leak between child render windows',
+  (t) => runLeakTest(t, makeLineActor2DCase())
+);
+
+test.onlyIfWebGL(
+  'Test 3D actor backface culling does not leak between child render windows',
+  (t) => runLeakTest(t, makeBackfaceCulledSphereCase())
+);

--- a/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.d.ts
@@ -16,6 +16,7 @@ import vtkViewStream from '../../../IO/Core/ImageStream/ViewStream';
  */
 export interface IOpenGLRenderWindowInitialValues {
   cullFaceEnabled?: boolean;
+  cullFaceMode?: number | null;
   shaderCache?: null;
   initialized?: boolean;
   context?: WebGLRenderingContext | WebGL2RenderingContext;
@@ -375,6 +376,13 @@ export interface vtkOpenGLRenderWindow extends vtkViewNode {
    *
    */
   enableCullFace(): void;
+
+  /**
+   * Set the cull face mode (gl.FRONT, gl.BACK, or gl.FRONT_AND_BACK).
+   * Caches the value to avoid redundant gl.cullFace() calls.
+   * @param mode A WebGL cull face mode constant.
+   */
+  setCullFaceMode(mode: number): void;
 
   /**
    *

--- a/Sources/Rendering/OpenGL/RenderWindow/index.js
+++ b/Sources/Rendering/OpenGL/RenderWindow/index.js
@@ -27,6 +27,7 @@ const parentMethodsToProxy = [
   'deactivateTexture',
   'disableCullFace',
   'enableCullFace',
+  'setCullFaceMode',
   'get3DContext',
   'getActiveFramebuffer',
   'getContext',
@@ -1143,6 +1144,13 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
     }
   };
 
+  publicAPI.setCullFaceMode = (mode) => {
+    if (model.cullFaceMode !== mode) {
+      model.context.cullFace(mode);
+      model.cullFaceMode = mode;
+    }
+  };
+
   publicAPI.setViewStream = (stream) => {
     if (model.viewStream === stream) {
       return false;
@@ -1302,6 +1310,7 @@ function vtkOpenGLRenderWindow(publicAPI, model) {
 
 const DEFAULT_VALUES = {
   cullFaceEnabled: false,
+  cullFaceMode: null,
   shaderCache: null,
   initialized: false,
   context: null,

--- a/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
+++ b/Sources/Rendering/OpenGL/SurfaceLIC/SurfaceLICMapper/index.js
@@ -134,7 +134,11 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
     apply(gl.BLEND);
     apply(gl.DEPTH_TEST);
     apply(gl.SCISSOR_TEST);
-    apply(gl.CULL_FACE);
+    if (model.stateCache[gl.CULL_FACE]) {
+      model._openGLRenderWindow.enableCullFace();
+    } else {
+      model._openGLRenderWindow.disableCullFace();
+    }
   };
 
   publicAPI.renderPiece = (ren, actor) => {
@@ -211,10 +215,10 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
       model._openGLRenderWindow.disableCullFace();
     } else if (frontfaceCulling) {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.FRONT);
+      model._openGLRenderWindow.setCullFaceMode(gl.FRONT);
     } else {
       model._openGLRenderWindow.enableCullFace();
-      gl.cullFace(gl.BACK);
+      model._openGLRenderWindow.setCullFaceMode(gl.BACK);
     }
 
     const windowSize = model._openGLRenderWindow.getSize();
@@ -241,7 +245,7 @@ function vtkOpenGLSurfaceLICMapper(publicAPI, model) {
     publicAPI.pushState(model.context);
     model.VBOBuildTime.modified();
     model.openGLLicInterface.completedGeometry();
-    model.context.disable(model.context.CULL_FACE);
+    model._openGLRenderWindow.disableCullFace();
     model.openGLLicInterface.applyLIC();
     model.openGLLicInterface.combineColorsAndLIC();
     model.openGLLicInterface.copyToScreen(windowSize);


### PR DESCRIPTION
## Summary

This fixes a WebGL state leak in `vtkOpenGLPolyDataMapper2D`. The mapper enables `CULL_FACE` while rendering 2D polydata, but it did not restore that state afterward. In a parent render window with multiple child render windows sharing one WebGL context, the leaked cull state can carry into the next child renderer and fully cull back-facing image slice quads, leaving the child viewport black on the next render.

The fix restores cull-face state after `renderPieceFinish()` and adds a regression test that renders two child render windows twice, with a `vtkActor2D` in the second child, then verifies the first child slice remains visible and `CULL_FACE` is disabled after rendering.

## Bisect

First bad commit:

`bdc7e0163bb5dc002cee7c446126a7dae2e4d9bd`

`feat(polydatamapper2d): cell scalar based coloring for PolyDataMapper2D`

