### PR TITLE
fix(macros): break reference cycles in getState

### DIFF
--- a/Sources/Proxy/Core/ProxyManager/core.js
+++ b/Sources/Proxy/Core/ProxyManager/core.js
@@ -11,13 +11,13 @@ export default function addRegistrationAPI(publicAPI, model) {
     if (!proxy) {
       return;
     }
-    model.proxyIdMapping[proxy.getProxyId()] = proxy;
+    model._proxyIdMapping[proxy.getProxyId()] = proxy;
     const group = proxy.getProxyGroup();
-    if (!model.proxyByGroup[group]) {
-      model.proxyByGroup[group] = [];
+    if (!model._proxyByGroup[group]) {
+      model._proxyByGroup[group] = [];
     }
-    if (model.proxyByGroup[group].indexOf(proxy) === -1) {
-      model.proxyByGroup[group].push(proxy);
+    if (model._proxyByGroup[group].indexOf(proxy) === -1) {
+      model._proxyByGroup[group].push(proxy);
     }
     proxy.setProxyManager(publicAPI);
 
@@ -37,18 +37,18 @@ export default function addRegistrationAPI(publicAPI, model) {
 
   function unRegisterProxy(proxyOrId) {
     const id = proxyOrId.getProxyId ? proxyOrId.getProxyId() : proxyOrId;
-    const proxy = model.proxyIdMapping[id];
+    const proxy = model._proxyIdMapping[id];
 
     // Unregister proxy in any group
-    Object.keys(model.proxyByGroup).forEach((groupName) => {
-      const proxyList = model.proxyByGroup[groupName];
+    Object.keys(model._proxyByGroup).forEach((groupName) => {
+      const proxyList = model._proxyByGroup[groupName];
       const index = proxyList.indexOf(proxy);
       if (index !== -1) {
         proxyList.splice(index, 1);
       }
     });
 
-    delete model.proxyIdMapping[id];
+    delete model._proxyIdMapping[id];
     proxy.gcPropertyLinks('application');
     proxy.gcPropertyLinks('source');
     proxy.setProxyManager(null);
@@ -96,23 +96,23 @@ export default function addRegistrationAPI(publicAPI, model) {
 
   // --------------------------------------------------------------------------
 
-  publicAPI.getProxyById = (id) => model.proxyIdMapping[id];
+  publicAPI.getProxyById = (id) => model._proxyIdMapping[id];
 
   // --------------------------------------------------------------------------
 
-  publicAPI.getProxyGroups = () => Object.keys(model.proxyByGroup);
+  publicAPI.getProxyGroups = () => Object.keys(model._proxyByGroup);
 
   // --------------------------------------------------------------------------
 
   publicAPI.getProxyInGroup = (name) =>
-    [].concat(model.proxyByGroup[name] || []);
+    [].concat(model._proxyByGroup[name] || []);
 
   // --------------------------------------------------------------------------
 
-  publicAPI.getSources = () => [].concat(model.proxyByGroup.Sources || []);
+  publicAPI.getSources = () => [].concat(model._proxyByGroup.Sources || []);
   publicAPI.getRepresentations = () =>
-    [].concat(model.proxyByGroup.Representations || []);
-  publicAPI.getViews = () => [].concat(model.proxyByGroup.Views || []);
+    [].concat(model._proxyByGroup.Representations || []);
+  publicAPI.getViews = () => [].concat(model._proxyByGroup.Views || []);
 
   // --------------------------------------------------------------------------
 

--- a/Sources/Proxy/Core/ProxyManager/index.js
+++ b/Sources/Proxy/Core/ProxyManager/index.js
@@ -11,8 +11,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(
     model,
     {
-      proxyIdMapping: {},
-      proxyByGroup: {},
+      _proxyIdMapping: {},
+      _proxyByGroup: {},
       proxyConfiguration: {}, // { definitions: {}, representations: { viewName: { sourceType: representationName } } }
       sv2rMapping: {}, // sv2rMapping[sourceId][viewId] = rep
       r2svMapping: {}, // r2svMapping[representationId] = { sourceId, viewId }

--- a/Sources/Testing/testGetStateCycles.js
+++ b/Sources/Testing/testGetStateCycles.js
@@ -1,0 +1,69 @@
+import { it, expect } from 'vitest';
+import macro from 'vtk.js/Sources/macros';
+
+// ----------------------------------------------------------------------------
+// vtkCycleNode: minimal vtkObject that references other vtkObjects
+// ----------------------------------------------------------------------------
+
+function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, { other: null, list: [] }, initialValues);
+  macro.obj(publicAPI, model);
+  model.classHierarchy.push('vtkCycleNode');
+  macro.setGet(publicAPI, model, ['other', 'list']);
+}
+
+const newInstance = macro.newInstance(extend, 'vtkCycleNode');
+
+it('Test getState breaks direct reference cycles', () => {
+  const a = newInstance();
+  const b = newInstance();
+  a.setOther(b);
+  b.setOther(a);
+
+  const state = a.getState();
+  expect(state.vtkClass).toBe('vtkCycleNode');
+  expect(state.other.vtkClass, 'the referenced object serializes').toBe(
+    'vtkCycleNode'
+  );
+  expect(state.other.other, 'the back reference serializes as null').toBeNull();
+
+  // JSON.stringify routes through toJSON()/getState() and must not throw.
+  expect(() => JSON.stringify(a)).not.toThrow();
+});
+
+it('Test getState breaks self references', () => {
+  const a = newInstance();
+  a.setOther(a);
+
+  expect(a.getState().other, 'a self reference serializes as null').toBeNull();
+});
+
+it('Test getState breaks reference cycles through arrays', () => {
+  const a = newInstance();
+  const b = newInstance();
+  a.setList([b]);
+  b.setList([a]);
+
+  const state = a.getState();
+  expect(state.list[0].vtkClass, 'the referenced object serializes').toBe(
+    'vtkCycleNode'
+  );
+  expect(
+    state.list[0].list[0],
+    'the back reference serializes as null'
+  ).toBeNull();
+});
+
+it('Test getState serializes shared references that are not cycles', () => {
+  const shared = newInstance();
+  const root = newInstance();
+  root.setList([shared, shared]);
+
+  const state = root.getState();
+  expect(state.list[0].vtkClass, 'the first occurrence serializes').toBe(
+    'vtkCycleNode'
+  );
+  expect(state.list[1].vtkClass, 'the second occurrence serializes too').toBe(
+    'vtkCycleNode'
+  );
+});

--- a/Sources/Testing/testProxy.js
+++ b/Sources/Testing/testProxy.js
@@ -77,6 +77,24 @@ it('Proxy activation via config', () => {
   proxy.getState();
 });
 
+it('Proxy getState serializes the proxy', () => {
+  const proxyManager = newProxyManager();
+  const proxy = proxyManager.createProxy('Sources', 'TrivialProducer');
+
+  const state = proxy.getState();
+  expect(state, 'getState returns a state, not null').not.toBeNull();
+  expect(state.vtkClass).toBe('vtkTestProxyClass');
+  expect(
+    state.proxyManager.vtkClass,
+    'the proxy manager serializes instead of recursing forever'
+  ).toBe('vtkProxyManager');
+
+  // JSON.stringify routes through toJSON()/getState() and must terminate
+  // even though the proxy and its manager reference each other.
+  expect(() => JSON.stringify(proxy)).not.toThrow();
+  expect(() => JSON.stringify(proxyManager)).not.toThrow();
+});
+
 it('Proxy activation via .activate()', () => {
   const proxyManager = newProxyManager();
   expect(

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -1492,9 +1492,6 @@ export function proxy(publicAPI, model) {
     parentDelete();
   };
 
-  // @todo fix infinite recursion due to active source
-  publicAPI.getState = () => null;
-
   function registerLinks() {
     // Allow dynamic registration of links at the application level
     if (model.links) {

--- a/Sources/macros.js
+++ b/Sources/macros.js
@@ -364,49 +364,66 @@ export function obj(publicAPI = {}, model = {}) {
   };
 
   // Add serialization support
-  publicAPI.getState = ({ preserveTypedArrays = false } = {}) => {
+  publicAPI.getState = (
+    { preserveTypedArrays = false } = {},
+    _ancestors = new WeakSet()
+  ) => {
     if (model.deleted) {
       return null;
     }
-    const options = { preserveTypedArrays };
-    const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
+    // Break reference cycles: an object already being serialized higher up
+    // the call chain serializes as null, like a deleted object. Shared
+    // references that do not cycle serialize at every occurrence.
+    if (_ancestors.has(model)) {
+      return null;
+    }
+    _ancestors.add(model);
+    try {
+      const options = { preserveTypedArrays };
+      const jsonArchive = { ...model, vtkClass: publicAPI.getClassName() };
 
-    // Convert every vtkObject to its serializable form
-    Object.keys(jsonArchive).forEach((keyName) => {
-      if (
-        jsonArchive[keyName] === null ||
-        jsonArchive[keyName] === undefined ||
-        keyName[0] === '_' // protected members start with _
-      ) {
-        delete jsonArchive[keyName];
-      } else if (jsonArchive[keyName].isA) {
-        jsonArchive[keyName] = jsonArchive[keyName].getState(options);
-      } else if (Array.isArray(jsonArchive[keyName])) {
-        jsonArchive[keyName] = jsonArchive[keyName].map((item) =>
-          item && item.isA ? item.getState(options) : item
-        );
-      } else if (isTypedArray(jsonArchive[keyName])) {
-        if (!preserveTypedArrays) {
-          jsonArchive[keyName] = Array.from(jsonArchive[keyName]);
+      // Convert every vtkObject to its serializable form
+      Object.keys(jsonArchive).forEach((keyName) => {
+        if (
+          jsonArchive[keyName] === null ||
+          jsonArchive[keyName] === undefined ||
+          keyName[0] === '_' // protected members start with _
+        ) {
+          delete jsonArchive[keyName];
+        } else if (jsonArchive[keyName].isA) {
+          jsonArchive[keyName] = jsonArchive[keyName].getState(
+            options,
+            _ancestors
+          );
+        } else if (Array.isArray(jsonArchive[keyName])) {
+          jsonArchive[keyName] = jsonArchive[keyName].map((item) =>
+            item && item.isA ? item.getState(options, _ancestors) : item
+          );
+        } else if (isTypedArray(jsonArchive[keyName])) {
+          if (!preserveTypedArrays) {
+            jsonArchive[keyName] = Array.from(jsonArchive[keyName]);
+          }
+          // else: keep TypedArray as-is for structured clone / postMessage
         }
-        // else: keep TypedArray as-is for structured clone / postMessage
-      }
-    });
-
-    // Sort resulting object by key name
-    const sortedObj = {};
-    Object.keys(jsonArchive)
-      .sort()
-      .forEach((name) => {
-        sortedObj[name] = jsonArchive[name];
       });
 
-    // Remove mtime
-    if (sortedObj.mtime) {
-      delete sortedObj.mtime;
-    }
+      // Sort resulting object by key name
+      const sortedObj = {};
+      Object.keys(jsonArchive)
+        .sort()
+        .forEach((name) => {
+          sortedObj[name] = jsonArchive[name];
+        });
 
-    return sortedObj;
+      // Remove mtime
+      if (sortedObj.mtime) {
+        delete sortedObj.mtime;
+      }
+
+      return sortedObj;
+    } finally {
+      _ancestors.delete(model);
+    }
   };
 
   // Add shallowCopy(otherInstance) support


### PR DESCRIPTION
### Context

`getState()` recurses into every vtkObject held by the model with no cycle tracking, so serializing any object graph that contains a back reference overflows the call stack:

```
RangeError: Maximum call stack size exceeded
  at publicAPI.getState (Sources/macros.js:368)
```

This bites in practice wherever `JSON.stringify` touches a vtkObject, because `toJSON()` routes through `getState()` — e.g. a test reporter serializing a failing `expect(textureA).toBe(textureB)` assertion walks the circular WebGPU device–texture graph and the stack overflow masks the actual assertion message. The proxy macro has carried a workaround for the same problem (`// @todo fix infinite recursion due to active source` above its `getState = () => null`), and `testSerialization.js` warns "If this test is hanging, it is due to a problem in `getState()`".

### Results

- `getState()` and `JSON.stringify(vtkObject)` terminate on cyclic object graphs: an object already being serialized higher up the call chain serializes as `null`, the same representation as a deleted object.
- Shared references that do not cycle (the same vtkObject reachable through two fields) still serialize in full at every occurrence, as before.
- Acyclic serialization output is unchanged.
- The `@todo` workaround in the proxy macro is resolved: `proxy.getState()` returns a real state instead of `null`, and `JSON.stringify` terminates on proxies and proxy managers.

### Changes

- `Sources/macros.js`: `getState()` threads a `WeakSet` of the models on the active serialization path through the recursion and returns `null` when it re-enters one of them. The set tracks the current path only (entries are removed once their subtree is serialized), not all visited objects, so shared non-cyclic references are preserved.
- `Sources/macros.js`: the proxy macro's `getState = () => null` stub is removed. **Behavior change**: `proxy.getState()` now returns a state object instead of `null`.
- `Sources/Proxy/Core/ProxyManager`: the internal proxy registries (`proxyIdMapping`, `proxyByGroup`, used only within ProxyManager) become protected fields (`_`-prefixed) so the manager's state no longer embeds live proxies inside plain containers, which `JSON.stringify` cannot handle.
- New tests in `Sources/Testing/testGetStateCycles.js`: direct cycle, self reference, cycle through an array, and a shared-reference control that pins the non-cycle behavior; new proxy serialization test in `Sources/Testing/testProxy.js`.
- No public API signature changes — the added `getState` parameter is internal and the documented signature `getState(options?: GetStateOptions): object` is unchanged.

- [x] Documentation and TypeScript definitions were updated to match those changes (none needed — no API signature changes)

### PR and Code Checklist

- [x] [semantic-release](https://github.com/semantic-release/semantic-release) commit messages
- [x] Run `npm run reformat` to have correctly formatted code

### Testing

```
npx vitest run \
  Sources/Testing/testGetStateCycles.js \
  Sources/Testing/testProxy.js \
  Sources/Testing/testSerialization.js \
  Sources/Testing/testMacro.js
```

The three cycle tests fail with `RangeError: Maximum call stack size exceeded` without the fix, and the proxy serialization test fails against both the `null` stub and the raw-registry `TypeError: Converting circular structure to JSON`. The existing serialization suite (which round-trips every serializable class and `JSON.stringify`s every instantiable class in the library), macro, and proxy tests all pass unchanged.

- [x] This change adds or fixes unit tests
- [x] Tested environment:
  - **vtk.js**: master (ca498ee75)
  - **OS**: Linux (WSL2 Ubuntu 24.04)
  - **Browser**: Chromium (Playwright, headless)
